### PR TITLE
DwC-A publishing bug

### DIFF
--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -36,7 +36,7 @@ class DwcArchiverCore extends Manager{
 	private $delimiter = ',';
 	private $fileExt = '.csv';
 	private $occurrenceFieldArr = array();
-	private $extensionFieldMap = array();
+	protected $extensionFieldMap = array();
 	private $isPublicDownload = false;
 	private $publicationGuid;
 	private $requestPortalGuid;

--- a/classes/DwcArchiverPublisher.php
+++ b/classes/DwcArchiverPublisher.php
@@ -19,6 +19,8 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 		$this->setCollArr($id);
 		$this->conditionArr['collid'] = $id;
 		$this->conditionSql = '';
+		unset($this->extensionFieldMap);
+		$this->extensionFieldMap = array();
 	}
 
 	public function verifyCollRecords($collId){

--- a/collections/datasets/datapublisher.php
+++ b/collections/datasets/datapublisher.php
@@ -480,31 +480,11 @@ if ($isEditor) {
 						$dwcaManager->setLimitToGuids(true);
 						foreach($collIdArr as $id){
 							$dwcaManager->resetCollArr($id);
-							if($includeAttributes){
-								if($dwcaManager->hasAttributes($id)) $dwcaManager->setIncludeAttributes(1);
-								else $dwcaManager->setIncludeAttributes(0);
-							}
-							if($includeMatSample){
-								if($dwcaManager->hasMaterialSamples($id)) $dwcaManager->setIncludeMaterialSample(1);
-								else  $dwcaManager->setIncludeMaterialSample(0);
-							}
-							if($includeIdentifiers){
-								if($dwcaManager->hasIdentifiers($id)) $dwcaManager->setIncludeIdentifiers(1);
-								else $dwcaManager->setIncludeIdentifiers(0);
-							}
-							if($includeAssociations){
-								if($dwcaManager->hasAssociations($id)) $dwcaManager->setIncludeAssociations(1);
-								else $dwcaManager->setIncludeAssociations(0);
-							}
 							if($dwcaManager->createDwcArchive()){
 								$dwcaManager->writeRssFile();
 								$collManager->batchTriggerGBIFCrawl(array($id));
 							}
 						}
-						$dwcaManager->setIncludeAttributes($includeAttributes);
-						$dwcaManager->setIncludeMaterialSample($includeMatSample);
-						$dwcaManager->setIncludeIdentifiers($includeIdentifiers);
-						$dwcaManager->setIncludeAssociations($includeAssociations);
 						echo '</ul>';
 						echo 'Batch process finished! (' . date('Y-m-d h:i:s A') . ')';
 					}


### PR DESCRIPTION
- Reset extensionFieldMap between each DwC-A build since this is used to determine which extension file should be added to the meta file. Previously code was causing adding invalid extension definitions to meta file due to existing within previous collection build.

